### PR TITLE
Added ability to pass custom defs-config.json as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ more information about `let`, `const` and `defs.js`. See also the blog post
 
 Then run it as `defs file.js`. The errors (if any) will go to stderr,
 the transpiled source to `stdout`, so redirect it like `defs file.js > output.js`.
+
+Configuration may be provided with `--config`: `defs --config path/to/defs-config.json file.js > output.js` 
 More command line options are coming.
 
 There's also a [Grunt](http://gruntjs.com/) plugin, see [grunt-defs](https://npmjs.org/package/grunt-defs).
@@ -36,8 +38,8 @@ See [CHANGES.md](CHANGES.md).
 
 
 ## Configuration
-`defs` looks for a `defs-config.json` configuration file in your current
-directory. If not found there, it searches parent directories until it hits `/`.
+If configuration is not provided using `--config` `defs` looks for a `defs-config.json` configuration file in your 
+current directory. If not found there, it searches parent directories until it hits `/`.
 
 Example `defs-config.json`:
 

--- a/defs-cmd.js
+++ b/defs-cmd.js
@@ -4,12 +4,17 @@ const fs = require("fs");
 const fmt = require("simple-fmt");
 const tryor = require("tryor");
 const defs = require("./defs-main");
+const yargs = require("yargs")
+    .options('config', {
+        describe: "path to defs config",
+    });
+const argv = yargs.argv;
 
-if (process.argv.length <= 2) {
-    console.log("USAGE: defs file.js");
+if (!argv._.length) {
+    console.log("USAGE: defs [options] file.js");
     process.exit(-1);
 }
-const filename = process.argv[2];
+const filename = argv._[0];
 
 if (!fs.existsSync(filename)) {
     console.log(fmt("error: file not found <{0}>", filename));
@@ -39,6 +44,10 @@ if (ret.src) {
 }
 
 function findAndReadConfig() {
+    if (argv.config) {
+        return JSON.parse(String(fs.readFileSync(argv.config)));
+    }
+
     let path = "";
     let filename = "defs-config.json";
     let filenamePath = null;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "stringmap": "~0.2.2",
     "stringset": "~0.2.1",
     "tryor": "~0.1.2",
-    "esprima": "git://github.com/ariya/esprima.git#harmony"
+    "esprima": "git://github.com/ariya/esprima.git#harmony",
+    "yargs": "~1.0.15"
   },
   "devDependencies": {
     "diff": "~1.0.8"


### PR DESCRIPTION
useful for cases where one want to store defs-config.json in some subdirectory instead of the main project directory

My use case:
Most of the times we use grunt-defs but for debugging purposes using defs as a command line tool is faster but one cannot provide the configuration without having `defs-config.json` in the project root.
