### PR TITLE
update notifier introduced

### DIFF
--- a/defs-cmd.js
+++ b/defs-cmd.js
@@ -4,14 +4,33 @@ const fs = require("fs");
 const fmt = require("simple-fmt");
 const tryor = require("tryor");
 const defs = require("./defs-main");
-const version = require("./package.json").version;
+const pkg = require('./package.json');
 const yargs = require("yargs")
-    .options("config", {});
+    .options("config", {})
+    .options("no-update-notifier", {});
 const argv = yargs.argv;
+
+if (!argv.noUpdateNotifier) {
+    const updateNotifier = require('update-notifier');
+    const notifier = updateNotifier({
+        packageName: pkg.name,
+        packageVersion: pkg.version,
+    });
+
+    if (notifier.update) {
+        const update = [
+            "defs v" + pkg.version + "",
+            "",
+            "Update available: " + notifier.update.latest,
+        ].join("\n");
+        console.error(update);
+        process.exit(-1);
+    }
+}
 
 if (!argv._.length) {
     const usage = [
-        "defs v" + version + "",
+        "defs v" + pkg.version + "",
         "",
         "Usage: defs OPTIONS <file>",
         "",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "stringmap": "~0.2.2",
     "stringset": "~0.2.1",
     "tryor": "~0.1.2",
-    "yargs": "~1.2.6"
+    "yargs": "~1.2.6",
+    "update-notifier": "~0.2.0"
   },
   "devDependencies": {
     "diff": "~1.0.8"


### PR DESCRIPTION
[Update notifier](https://github.com/yeoman/update-notifier/) checks for latest version of defs every 1 day (default check interval for update notifier package) if installed defs version is the latest available.
notification, as well as checking itself may be suppressed by passing `--no-update-notifier` option.

I intentionally did not update the README - there's no section for options yet and I don't want to introduce one myself. Please start one at your own will to make options documentation easier.
