### PR TITLE
Fix dependency for machines behind proxies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "alter": "~0.2.0",
     "ast-traverse": "~0.1.1",
     "breakable": "~1.0.0",
-    "esprima": "git://github.com/ariya/esprima.git#harmony",
+    "esprima": "git+https://github.com/ariya/esprima.git#harmony",
     "simple-fmt": "~0.1.0",
     "simple-is": "~0.2.0",
     "stringmap": "~0.2.2",


### PR DESCRIPTION
Hi there

Since the update of the `metalsmith` package my dependency tree looks like that:
- `metalsmith@1.0.1`
  - `gnode@0.1.0` 
    - `regenerator@0.6.10` 
      - `defs@1.0.1`
        - `esprima@git://github.com/ariya/esprima.git#harmony`

Since I'm using npm behind a corporate proxy which doesn't allow `git://` requests, the installation of the packages fails because of the dependency to esprima.

I suggest we change `git://` to `git+https://`, so the package can be fetched via `https`. Then we could move the `1.0.1` tag to the new commit. That way no changes to the dependant packages are necessary.
