### PR TITLE
Use Esprima 2.

### DIFF
--- a/defs-main.js
+++ b/defs-main.js
@@ -71,6 +71,11 @@ function isLvalue(node) {
 function createScopes(node, parent) {
     assert(!node.$scope);
 
+    // https://github.com/jquery/esprima/issues/1030
+    if (node.type === 'TryStatement') {
+        delete node.handlers;
+    }
+
     node.$parent = parent;
     node.$scope = node.$parent ? node.$parent.$scope : null; // may be overridden
 

--- a/options.js
+++ b/options.js
@@ -4,5 +4,5 @@ module.exports = {
     disallowVars: false,
     disallowDuplicated: true,
     disallowUnknownReferences: true,
-    parse: require("esprima-fb").parse,
+    parse: require("esprima").parse,
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "alter": "~0.2.0",
     "ast-traverse": "~0.1.1",
     "breakable": "~1.0.0",
-    "esprima-fb": "~8001.1001.0-dev-harmony-fb",
+    "esprima": "~2.5.0",
     "simple-fmt": "~0.1.0",
     "simple-is": "~0.2.0",
     "stringmap": "~0.2.2",


### PR DESCRIPTION
Facebook's fork is deprecated. Using the upstream Esprima 2 since it already supports ES6 features.